### PR TITLE
Remove license from fernignore

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,0 +1,4 @@
+LICENSE.md
+SECURITY.md
+.github/CODEOWNERS
+third-party-licenses.txt

--- a/.fernignore
+++ b/.fernignore
@@ -1,4 +1,3 @@
-LICENSE.md
 SECURITY.md
 .github/CODEOWNERS
 third-party-licenses.txt


### PR DESCRIPTION
Fern can pull a LICENSE.md from our source repo and push it to each of our destination repos. Removing this so it can be rolled into the generated PRs. 